### PR TITLE
Replace ERB+IO with File.read

### DIFF
--- a/bin/redis-browser
+++ b/bin/redis-browser
@@ -18,9 +18,7 @@ OptionParser.new do |opts|
 
   opts.on("-C PATH", "--config PATH", "Path to YAML config file") do |v|
     require 'yaml'
-    require 'erb'
-
-    config = YAML.load(ERB.new(IO.read(v)).result)
+    config = YAML.load(File.read(v))
     RedisBrowser.configure(config)
   end
 


### PR DESCRIPTION
I don't know why ERB was being used to parse the YAML config. But as far as I can tell, it just obfuscates the code.
