### PR TITLE
Add redis-like options

### DIFF
--- a/bin/redis-browser
+++ b/bin/redis-browser
@@ -29,10 +29,10 @@ optparse = OptionParser.new do |opts|
   end
 
   ## Sinatra options ##
-  opts.on("-B ADDRESS", "--bind ADDRESS", "Server hostname or IP address to listen on") do |v|
+  opts.on("-B ADDRESS", "--bind ADDRESS", "Sinatra hostname or IP to listen on") do |v|
     sinatra_options['bind'] = v
   end
-  opts.on("-P PORT", "--port PORT", "Port number to listen on") do |v|
+  opts.on("-P PORT", "--port PORT", "Sinatra port to listen on (default: 4567)") do |v|
     sinatra_options['port'] = v
   end
 

--- a/bin/redis-browser
+++ b/bin/redis-browser
@@ -8,29 +8,55 @@ require 'optparse'
 require "redis-browser"
 
 # Sinatra runtime options
-options = {
+sinatra_options = {
   bind: '127.0.0.1',
   port: 4567
 }
 
-OptionParser.new do |opts|
+# Store RedisBrowser config
+redis_config = RedisBrowser::DEFAULTS
+
+optparse = OptionParser.new do |opts|
   opts.banner = "Usage: redis-browser [options]"
 
+  ## YAML config ##
   opts.on("-C PATH", "--config PATH", "Path to YAML config file") do |v|
     require 'yaml'
     require 'erb'
 
-    config = YAML.load(ERB.new(IO.read(v)).result)
-    RedisBrowser.configure(config)
+    redis_config = YAML.load(ERB.new(IO.read(v)).result)
+    RedisBrowser.configure(redis_config)
   end
 
+  ## Sinatra options ##
   opts.on("-B ADDRESS", "--bind ADDRESS", "Server hostname or IP address to listen on") do |v|
-    options['bind'] = v
+    sinatra_options['bind'] = v
   end
-
   opts.on("-P PORT", "--port PORT", "Port number to listen on") do |v|
-    options['port'] = v
+    sinatra_options['port'] = v
   end
-end.parse!
 
-RedisBrowser::Web.run! options
+  ## redis-cli options ##
+  opts.on("-h <hostname>", "Server hostname (default: 127.0.0.1)") do |v|
+    redis_config['connections']['default']['host'] = v
+  end
+  opts.on("-p <port>", "Server port (default: 6379)") do |v|
+    redis_config['connections']['default']['port'] = v
+  end
+  opts.on("-a <password>", "Password to use when connecting to the server") do |v|
+    redis_config['connections']['default']['auth'] = v
+  end
+  opts.on("-n <db>", "Database number") do |v|
+    redis_config['connections']['default']['db'] = v
+  end
+end
+
+begin
+    optparse.parse!
+rescue OptionParser::MissingArgument, OptionParser::InvalidOption
+    puts optparse
+    exit 1
+end
+
+RedisBrowser.configure(redis_config)
+RedisBrowser::Web.run!(sinatra_options)

--- a/bin/redis-browser
+++ b/bin/redis-browser
@@ -29,7 +29,7 @@ optparse = OptionParser.new do |opts|
   end
 
   ## Sinatra options ##
-  opts.on("-B ADDRESS", "--bind ADDRESS", "Sinatra hostname or IP to listen on") do |v|
+  opts.on("-B ADDRESS", "--bind ADDRESS", "Sinatra hostname or IP to listen on (default: 127.0.0.1)") do |v|
     sinatra_options['bind'] = v
   end
   opts.on("-P PORT", "--port PORT", "Sinatra port to listen on (default: 4567)") do |v|

--- a/bin/redis-browser
+++ b/bin/redis-browser
@@ -46,7 +46,7 @@ optparse = OptionParser.new do |opts|
   opts.on("-a <password>", "Password to use when connecting to the server") do |v|
     redis_config['connections']['default']['auth'] = v
   end
-  opts.on("-n <db>", "Database number") do |v|
+  opts.on("-n <db>", "Database number (default: 0)") do |v|
     redis_config['connections']['default']['db'] = v
   end
 end

--- a/lib/redis-browser.rb
+++ b/lib/redis-browser.rb
@@ -11,7 +11,10 @@ require 'redis-browser/web'
 module RedisBrowser
   DEFAULTS = {
     'connections' => {
-      'default' => 'redis://127.0.0.1:6379/0'
+      'default' => {
+        'host' => '127.0.0.1',
+        'port' => '6379'
+      }
     }
   }
 

--- a/lib/redis-browser.rb
+++ b/lib/redis-browser.rb
@@ -13,7 +13,8 @@ module RedisBrowser
     'connections' => {
       'default' => {
         'host' => '127.0.0.1',
-        'port' => '6379'
+        'port' => '6379',
+        'db' => '0'
       }
     }
   }

--- a/lib/redis-browser/version.rb
+++ b/lib/redis-browser/version.rb
@@ -1,3 +1,3 @@
 module RedisBrowser
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/lib/redis-browser/web.rb
+++ b/lib/redis-browser/web.rb
@@ -53,7 +53,6 @@ module RedisBrowser
 
     def browser
       conn = settings.connections[params[:connection]]
-      conn = {url: conn} unless conn.is_a?(Hash)
       @browser ||= Browser.new(conn)
     end
   end


### PR DESCRIPTION
``` bash
-h <hostname>  Server hostname (default: 127.0.0.1)
-p <port>      Server port (default: 6379)
-a <password>  Password to use when connecting to the server
-n <db>        Database number
```

All of these options affect the 'default' connection.

Now you can run,

``` bash
$ redis-browser -h 10.0.10.5 -a "password123"
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/monterail/redis-browser/12)

<!-- Reviewable:end -->
