### PR TITLE
Export csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * Search keys
 * Can be mounted to Rails applications as engine
 * Can connect to multiple databases
+* Export keys as CSV
 
 ## Installation
 

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,7 @@
 connections:
   localhost:
     url: redis://127.0.0.1:6379/0
+    exclude_pattern: "^.+/total/.+$"
   other:
     host: 127.0.0.1
     port: 6379

--- a/lib/redis-browser.rb
+++ b/lib/redis-browser.rb
@@ -1,3 +1,4 @@
+require 'csv'
 require 'sinatra/base'
 require 'multi_json'
 require 'sinatra/json'
@@ -11,7 +12,10 @@ require 'redis-browser/web'
 module RedisBrowser
   DEFAULTS = {
     'connections' => {
-      'default' => 'redis://127.0.0.1:6379/0'
+      'default' => {
+        'url' => 'redis://127.0.0.1:6379/0',
+        'exclude-pattern' => ''
+      }
     }
   }
 

--- a/lib/redis-browser/browser.rb
+++ b/lib/redis-browser/browser.rb
@@ -125,6 +125,27 @@ module RedisBrowser
       }.merge(data)
     end
 
+    def exportCSV(include_pattern, exclude_pattern)
+      key = include_pattern
+      key << "*" unless key.end_with?("*")
+      exclude_rx = Regexp.new(exclude_pattern)
+      keys = redis.keys(key).select { |k| exclude_rx.match(k).nil? }
+      values = redis.multi do |multi|
+        keys.each { |k| multi.get(k) }
+      end
+      kv = keys.zip(values)
+
+      csv_string = CSV.generate do |csv|
+        kv.each do |k, v|
+          line = k.split(/[:\/]/) << v
+          csv << line
+        end
+      end
+      csv_string
+    rescue => ex
+      {:error => ex.message}
+    end
+
     def ping
       redis.ping == "PONG"
       {:ok => 1}

--- a/lib/redis-browser/public/css/app.css
+++ b/lib/redis-browser/public/css/app.css
@@ -34,11 +34,16 @@ body {
   margin-right: 5px;
 }
 
+.help-block {
+  font-size: 0.9em;
+  color: gray;
+}
+
 
 .value-list-index { width: 30px; }
 .value-zset-score { width: 30px; }
 .per-page { margin-top: 25px; }
-.connection-info { padding-right: 20px; }
+.header-item { padding-right: 20px; }
 .keys-search { width: 100px; }
 
 #http-loader {

--- a/lib/redis-browser/templates/coffee/app.coffee
+++ b/lib/redis-browser/templates/coffee/app.coffee
@@ -22,7 +22,7 @@ app.factory 'API', ['$http', ($http) ->
   (connection) ->
     ps = {connection: connection}
     {
-      exportCSV: (params) -> $http.get("#{jsEnv.root_path}exportCSV", {
+      exportCSV: (params) -> $http.get("#{jsEnv.root_path}export-csv", {
         params: angular.extend({}, ps, params)
       }).then (e) -> e,
 
@@ -111,14 +111,15 @@ app.factory 'API', ['$http', ($http) ->
 
     close: ->
       $scope.export.show = false
-
-    run: ->
       $scope.export.error = null
 
+    run: ->
       $scope.api.exportCSV(
         include: $scope.export.include,
         exclude: $scope.export.exclude
       ).then (response) ->
+        $scope.export.error = null
+
         content = response.data
         if response.headers('Content-Type').includes("text/csv")
           hiddenElement = document.createElement('a')
@@ -129,6 +130,12 @@ app.factory 'API', ['$http', ($http) ->
           hiddenElement.click()
 
           $scope.config.close()
+
+          destroyA = setInterval( ->
+              hiddenElement.remove()
+              clearInterval(destroyA)
+            , 5000
+          )
 
         else
           $scope.export.error = content.error

--- a/lib/redis-browser/templates/index.slim
+++ b/lib/redis-browser/templates/index.slim
@@ -48,6 +48,43 @@ html ng-app="browser"
             ' {{ config.error }}
           button.btn.btn-success type="submit" ng-click="config.save()" Save
 
+    div modal="export.show" close="export.close()" options="config.modalOpts"
+      .form-horizontal
+        .modal-header
+          button.close type="button" ng-click="export.close()" &times;
+          h4 Export CSV
+        .modal-body
+          .control-group
+            label.control-label for="export-include" Include keys
+            .controls
+              input.form-control id="export-include" ng-model="export.include" ng-required="required" type="text"
+
+          .control-group
+            label.control-label for="export-exclude" Exclude keys pattern
+            .controls
+              input.form-control id="export-exclude" ng-model="export.exclude" type="text"
+
+          .control-group
+            label.control-label for="export-filename" File name
+            .controls
+              input.form-control id="export-filename" ng-model="export.filename" ng-required="required" type="text"
+
+          span.help-block
+           b Include keys
+           |  is keys to include in the output as per
+           a href="http://redis.io/commands/KEYS" target="_blank"  KEYS
+           | .
+           br
+           b Exclude keys pattern
+           |  is a
+           a href="https://en.wikipedia.org/wiki/Regular_expression" target="_blank"  regex
+           |  which excludes the keys from the output.
+
+        .modal-footer
+          span.alert.alert-error.pull-left ng-show="export.error"
+            ' {{ export.error }}
+          button.btn.btn-success type="submit" ng-click="export.run()" Export
+
     .navbar.navbar-inverse.navbar-fixed-top
       .navbar-inner
         .container-fluid
@@ -58,8 +95,10 @@ html ng-app="browser"
 
           .nav-collapse.collapse
             p.pull-right
+              button.btn.btn-default ng-click="export.open()" Export CSV
+            p.pull-right.header-item
               button.btn.btn-success ng-click="config.open()" Configure
-            p.navbar-text.pull-right.connection-info
+            p.navbar-text.pull-right.header-item
               ' Connected to
               strong
                 ' {{ config.connection }}

--- a/lib/redis-browser/web.rb
+++ b/lib/redis-browser/web.rb
@@ -34,6 +34,17 @@ module RedisBrowser
       slim :index
     end
 
+    get '/exportCSV' do
+      result = browser.exportCSV(params[:include], params[:exclude])
+      if result.is_a? String
+        content_type 'text/csv'
+        attachment "redis-dump.csv"
+        result
+      else
+        json result
+      end
+    end
+
     get '/ping.json' do
       json browser.ping
     end

--- a/lib/redis-browser/web.rb
+++ b/lib/redis-browser/web.rb
@@ -34,7 +34,7 @@ module RedisBrowser
       slim :index
     end
 
-    get '/exportCSV' do
+    get '/export-csv' do
       result = browser.exportCSV(params[:include], params[:exclude])
       if result.is_a? String
         content_type 'text/csv'


### PR DESCRIPTION
# Idea

Quiet often while working with Redis the user might feel a need to
have counters per event. Events could obey some hierarchy, i.e.

```
user/1/newPosts
user/2/newPosts
...
user/n/newPosts

user/1/to-user/2/messages
user/3/to-user/1/messages
```

Would be useful if redis-browser could somehow represent the data from
all of these keys in some kind of a table view.
# Realization

MS Excel, OS X Numbers, Libreoffice alternative - these are all good
examples of software which can pivot, sort, filter, slice and dice table
data (even hierarchial data).

This commit addresses an Export to CSV format to be consumed by such
apps.
# Implementation

"Export CSV" is an extra button in the top-right corner of the header.
When clicked, opens a form similar to "Configure Redis Connection" form.
From there the user is able to choose:
- Include keys - keys to include in the output as per Redis KEYS man.
- Exclude keys pattern - regex which excludes the keys from the output.
- Filename - a file with that name will be downloaded if export was good.

Only Redis String datatype is supported for exported keys for a reason -
the keys and values are extracted to be opened in MS Excel, Libreoffice
alternative or OS X Numbers.

Keys are broken down in separate CSV fields the same way the keys are
broken down into a hierarchy view on the lefthand side of the UI - by
delimiter `[:/]`
# Configuration

**"Exclude keys pattern"** comes from config.yml. A connection now has an
optional parameter - exclude_pattern. Example

```
exclude_pattern: "^.+/total/.+$"
```

**"Include keys"** - if no key is selected from the tree on the left hand
side - `"*"`, otherwise - the selected key.
