### PR TITLE
Allow user to bookmark specific keys

### DIFF
--- a/lib/redis-browser/templates/coffee/app.coffee
+++ b/lib/redis-browser/templates/coffee/app.coffee
@@ -192,3 +192,11 @@ app.directive 'prettyprint', ->
 
   # Init
   $scope.fetchKeys()
+
+
+  # If user has loaded page from a bookmark of a specific key...
+  if ( window.location.hash != null && window.location.hash != "" )
+    # Show the selected key
+    key = {name: "", full: window.location.hash.substr(2), count: 1, $$hashKey: ""}
+    $scope.show( key )
+    # TODO: expand tree to show this key

--- a/lib/redis-browser/templates/index.slim
+++ b/lib/redis-browser/templates/index.slim
@@ -187,7 +187,7 @@ html ng-app="browser"
                     input.input-medium.search-query type="text" ng-model="query" placeholder="Search"
                 tr ng-repeat="e in key.values | filter:query"
                   td
-                    a href="#" ng-click="show(e)"
+                    a href="\#{{e.full}}" ng-click="show(e)"
                       ' {{ e.name }}
                   td
                     button.btn.btn-danger ng-click="deleteKey(e)" Delete

--- a/lib/redis-browser/templates/index.slim
+++ b/lib/redis-browser/templates/index.slim
@@ -22,7 +22,7 @@ html ng-app="browser"
         button.btn.tree-toggle ng-show="key.open" ng-click="keyClose(key)" -
       span ng-show="key.count == 1" -&nbsp;
 
-      a href="#" ng-click="show(key)"
+      a href="\#{{key.full}}" ng-click="show(key)"
         ' {{ key.name }}
         small ng-show="key.count > 1"
           | ({{ key.count }})


### PR DESCRIPTION
When clicking a key, browser URL will update to, e.g.

http://127.0.0.1:4567/#/my_key:goes:here:

When loading the page, if there is something like this in the URL, open the relevant key