### PR TITLE
ignoring rbenv conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .DS_Store
+.ruby-version


### PR DESCRIPTION
For those who use rbenv, simply add the corresponding line in .gitignore