### PR TITLE
[azazelo] add e.value in table view

### DIFF
--- a/lib/redis-browser/templates/index.slim
+++ b/lib/redis-browser/templates/index.slim
@@ -86,6 +86,7 @@ html ng-app="browser"
 
           div ng-switch="key.type"
             pre ng-switch-when="string" prettyprint="key.value"
+              ' {{ key.value }}
 
             pre ng-switch-when="json"
               ' {{ key.value | json }}

--- a/lib/redis-browser/templates/index.slim
+++ b/lib/redis-browser/templates/index.slim
@@ -135,6 +135,7 @@ html ng-app="browser"
                       pre ng-switch-when="json"
                         ' {{ e.value | json }}
                       pre ng-switch-default="" prettyprint="e.value"
+                        ' {{ e.value }}
 
             div ng-switch-when="list"
               .alert


### PR DESCRIPTION
There is missing e.value in table view. 
There is missing key.value when type is 'string'. 

This pull request fix these issues. 
Please merge it. 