### PR TITLE
Set upper bound for sinatra to < 3.0

### DIFF
--- a/redis-browser.gemspec
+++ b/redis-browser.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency "sinatra"
+  spec.add_runtime_dependency "sinatra", "< 3.0"
   spec.add_runtime_dependency "sinatra-contrib"
   spec.add_runtime_dependency "slim"
   spec.add_runtime_dependency "sass"


### PR DESCRIPTION
  Sinatra introduced a breaking change in 3.0 that removed support for several templates including Coffee script. This causes an error `Undefined method 'coffee' for class 'RedisBrowser::CoffeeHandler'`

 -  [Discussion around change](https://github.com/sinatra/sinatra/issues/1759)
 -  [The actual change](https://github.com/sinatra/sinatra/pull/1790)
 -  [Changelog](https://github.com/sinatra/sinatra/pull/1790)


